### PR TITLE
Changes to enable custom dates

### DIFF
--- a/apps/stocks/src/environments/environment.ts
+++ b/apps/stocks/src/environments/environment.ts
@@ -6,7 +6,7 @@ import { StocksAppConfig } from '@coding-challenge/stocks/data-access-app-config
 
 export const environment: StocksAppConfig = {
   production: false,
-  apiKey: '',
+  apiKey: 'Tpk_4a78b4b7fccc4441804ab5785df190eb',
   apiURL: 'https://sandbox.iexapis.com'
 };
 

--- a/libs/shared/ui/chart/src/lib/chart/chart.component.html
+++ b/libs/shared/ui/chart/src/lib/chart/chart.component.html
@@ -1,5 +1,5 @@
 <google-chart
-  *ngIf="data"
+  *ngIf="chartData"
   [title]="chart.title"
   [type]="chart.type"
   [data]="chartData"

--- a/libs/stocks/data-access-price-query/src/lib/+state/price-query.actions.ts
+++ b/libs/stocks/data-access-price-query/src/lib/+state/price-query.actions.ts
@@ -10,7 +10,12 @@ export enum PriceQueryActionTypes {
 
 export class FetchPriceQuery implements Action {
   readonly type = PriceQueryActionTypes.FetchPriceQuery;
-  constructor(public symbol: string, public period: string) {}
+  constructor(
+    public symbol: string,
+    public period: string,
+    public fromDate: string,
+    public toDate: string
+  ) {}
 }
 
 export class PriceQueryFetchError implements Action {

--- a/libs/stocks/data-access-price-query/src/lib/+state/price-query.effects.ts
+++ b/libs/stocks/data-access-price-query/src/lib/+state/price-query.effects.ts
@@ -29,7 +29,14 @@ export class PriceQueryEffects {
             }?token=${this.env.apiKey}`
           )
           .pipe(
-            map(resp => new PriceQueryFetched(resp as PriceQueryResponse[]))
+            map(
+              (resp: any[]) =>
+                new PriceQueryFetched(resp.filter(
+                  stockData =>
+                    new Date(stockData.date) >= new Date(action.fromDate) &&
+                    new Date(stockData.date) <= new Date(action.toDate)
+                ) as PriceQueryResponse[])
+            )
           );
       },
 

--- a/libs/stocks/data-access-price-query/src/lib/+state/price-query.facade.ts
+++ b/libs/stocks/data-access-price-query/src/lib/+state/price-query.facade.ts
@@ -18,7 +18,7 @@ export class PriceQueryFacade {
 
   constructor(private store: Store<PriceQueryPartialState>) {}
 
-  fetchQuote(symbol: string, period: string) {
-    this.store.dispatch(new FetchPriceQuery(symbol, period));
+  fetchQuote(symbol: string, period: string, fromDate: string, toDate: string) {
+    this.store.dispatch(new FetchPriceQuery(symbol, period, fromDate, toDate));
   }
 }

--- a/libs/stocks/feature-shell/src/lib/stocks-feature-shell.module.ts
+++ b/libs/stocks/feature-shell/src/lib/stocks-feature-shell.module.ts
@@ -4,7 +4,9 @@ import {
   MatFormFieldModule,
   MatInputModule,
   MatSelectModule,
-  MatButtonModule
+  MatButtonModule,
+  MatNativeDateModule,
+  MatDatepickerModule
 } from '@angular/material';
 import { RouterModule } from '@angular/router';
 import { SharedUiChartModule } from '@coding-challenge/shared/ui/chart';
@@ -18,6 +20,8 @@ import { ReactiveFormsModule } from '@angular/forms';
       { path: '', pathMatch: 'full', component: StocksComponent }
     ]),
     ReactiveFormsModule,
+    MatDatepickerModule,
+    MatNativeDateModule,
     MatFormFieldModule,
     MatInputModule,
     MatSelectModule,

--- a/libs/stocks/feature-shell/src/lib/stocks/stocks.component.html
+++ b/libs/stocks/feature-shell/src/lib/stocks/stocks.component.html
@@ -18,15 +18,51 @@
   </mat-form-field>
 
   <mat-form-field>
-    <mat-label>Favorite time period</mat-label>
-    <mat-select formControlName="period">
-      <mat-option
-        *ngFor="let timePeriod of timePeriods"
-        [value]="timePeriod.value"
+    <input
+      matInput
+      formControlName="fromDate"
+      [min]="minDate"
+      [max]="currentDate"
+      [matDatepicker]="fromDate"
+      placeholder="From Date"
+      (dateInput)="changeDate()"
+      (dateChange)="changeDate()"
+    />
+    <mat-datepicker-toggle matSuffix [for]="fromDate"></mat-datepicker-toggle>
+    <mat-datepicker #fromDate></mat-datepicker>
+    <mat-error
+      ><span
+        *ngIf="
+          !stockPickerForm.get('fromDate').valid &&
+          stockPickerForm.get('fromDate').touched
+        "
+        >Please enter From Date</span
       >
-        {{ timePeriod.viewValue }}
-      </mat-option>
-    </mat-select>
+    </mat-error>
+  </mat-form-field>
+
+  <mat-form-field>
+    <input
+      matInput
+      formControlName="toDate"
+      [min]="minDate"
+      [max]="currentDate"
+      [matDatepicker]="toDate"
+      placeholder="To Date"
+      (dateInput)="changeDate()"
+      (dateChange)="changeDate()"
+    />
+    <mat-datepicker-toggle matSuffix [for]="toDate"> </mat-datepicker-toggle>
+    <mat-datepicker #toDate></mat-datepicker>
+    <mat-error
+      ><span
+        *ngIf="
+          !stockPickerForm.get('toDate').valid &&
+          stockPickerForm.get('toDate').touched
+        "
+        >Please enter To Date</span
+      >
+    </mat-error>
   </mat-form-field>
 
   <button (click)="fetchQuote()" mat-raised-button>Go</button>

--- a/libs/stocks/feature-shell/src/lib/stocks/stocks.component.ts
+++ b/libs/stocks/feature-shell/src/lib/stocks/stocks.component.ts
@@ -1,6 +1,8 @@
 import { Component, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { PriceQueryFacade } from '@coding-challenge/stocks/data-access-price-query';
+import { subYears, format } from 'date-fns';
+import { STOCKCONSTANTS } from './stocks.constants';
 
 @Component({
   selector: 'coding-challenge-stocks',
@@ -11,24 +13,18 @@ export class StocksComponent implements OnInit {
   stockPickerForm: FormGroup;
   symbol: string;
   period: string;
+  fromDate: Date;
+  toDate: Date;
+  minDate: Date = subYears(new Date(), STOCKCONSTANTS.YEARS_5);
+  currentDate = new Date();
 
   quotes$ = this.priceQuery.priceQueries$;
-
-  timePeriods = [
-    { viewValue: 'All available data', value: 'max' },
-    { viewValue: 'Five years', value: '5y' },
-    { viewValue: 'Two years', value: '2y' },
-    { viewValue: 'One year', value: '1y' },
-    { viewValue: 'Year-to-date', value: 'ytd' },
-    { viewValue: 'Six months', value: '6m' },
-    { viewValue: 'Three months', value: '3m' },
-    { viewValue: 'One month', value: '1m' }
-  ];
 
   constructor(private fb: FormBuilder, private priceQuery: PriceQueryFacade) {
     this.stockPickerForm = fb.group({
       symbol: [null, Validators.required],
-      period: [null, Validators.required]
+      fromDate: [null, Validators.required],
+      toDate: [null, Validators.required]
     });
   }
 
@@ -36,8 +32,24 @@ export class StocksComponent implements OnInit {
 
   fetchQuote() {
     if (this.stockPickerForm.valid) {
-      const { symbol, period } = this.stockPickerForm.value;
-      this.priceQuery.fetchQuote(symbol, period);
+      const { symbol, fromDate, toDate } = this.stockPickerForm.value;
+      this.priceQuery.fetchQuote(
+        symbol,
+        STOCKCONSTANTS.MAX,
+        format(fromDate, STOCKCONSTANTS.DATE_FORMAT),
+        format(toDate, STOCKCONSTANTS.DATE_FORMAT)
+      );
+    }
+  }
+
+  changeDate() {
+    const { symbol, fromDate, toDate } = this.stockPickerForm.value;
+    if (toDate && fromDate && toDate < fromDate) {
+      this.stockPickerForm.setValue({
+        symbol: symbol,
+        fromDate: toDate,
+        toDate: toDate
+      });
     }
   }
 }

--- a/libs/stocks/feature-shell/src/lib/stocks/stocks.constants.ts
+++ b/libs/stocks/feature-shell/src/lib/stocks/stocks.constants.ts
@@ -1,0 +1,7 @@
+const STOCKCONSTANTS = {
+  YEARS_5: 5,
+  MAX: 'max',
+  DATE_FORMAT: 'YYYY-MM-DD'
+};
+
+export { STOCKCONSTANTS };


### PR DESCRIPTION
Changes done as part of this PR:
1) Added token for successful API call - environment.ts
2) HTML change to load the chart - chart.component.html
3) Changes in data access to pass fromDate and toDate to be used for filtering logic.
4) Change for filtering dates based on custom selected fromDate and toDate - price-query.effects.ts 
5) Added required modules - stocks-feature-shell.module.ts 
6) Added date-pickers for fromDate and toDate with validation - stocks.component.html
7) Added the below conditions - 
	a) Disable future date selection.
	b) Disable dates prior to 5 years as it is the max from API response.
	c) Logic to set same date if toDate selected is less than fromDate.
8) Added constants file.

PFB the screenshot for custom date selection and response:
![image](https://user-images.githubusercontent.com/60125332/72808494-a978c980-3c7f-11ea-8f57-d6338267b266.png)

PFB the screenshot for same date selection and response:
![image](https://user-images.githubusercontent.com/60125332/72808510-b1d10480-3c7f-11ea-95cb-b4934d0c1e2f.png)

PFB the screenshot for disabling future date:
![image](https://user-images.githubusercontent.com/60125332/72808522-b990a900-3c7f-11ea-9966-e5a8a5002f1b.png)
