### PR TITLE
Implement hapijs changes and caching

### DIFF
--- a/apps/stocks-api/src/main.ts
+++ b/apps/stocks-api/src/main.ts
@@ -3,6 +3,7 @@
  * This is only a minimal backend to get started.
  **/
 import { Server } from 'hapi';
+import { stocksPlugin } from './plugin/stocks.plugin';
 
 const init = async () => {
   const server = new Server({
@@ -10,22 +11,19 @@ const init = async () => {
     host: 'localhost'
   });
 
-  server.route({
-    method: 'GET',
-    path: '/',
-    handler: (request, h) => {
-      return {
-        hello: 'world'
-      };
-    }
+  server.cache.provision({
+    provider: {
+      constructor: require('@hapi/catbox-memory')
+    },
+    name: 'stock-details-cache'
   });
 
+  await server.register(stocksPlugin);
   await server.start();
   console.log('Server running on %s', server.info.uri);
 };
 
 process.on('unhandledRejection', err => {
-  console.log(err);
   process.exit(1);
 });
 

--- a/apps/stocks-api/src/plugin/stocks.api.constants.ts
+++ b/apps/stocks-api/src/plugin/stocks.api.constants.ts
@@ -1,0 +1,13 @@
+const STOCKAPICONSTANTS = {
+  STOCKSPLUGIN: 'stocksPlugin',
+  VERSION: '1.0.0',
+  STOCK_DETAILS: 'stockDetails',
+  STOCK_DETAILS_CACHE: 'stock-details-cache',
+  EXPIRY_TIME: 60 * 1000,
+  TIMEOUT: 5000,
+  GET: 'GET',
+  PATH: '/api/v1/stock/{symbol}/{period}/{token}',
+  APIURI: 'https://sandbox.iexapis.com/beta/stock'
+};
+
+export { STOCKAPICONSTANTS };

--- a/apps/stocks-api/src/plugin/stocks.plugin.ts
+++ b/apps/stocks-api/src/plugin/stocks.plugin.ts
@@ -1,0 +1,40 @@
+import { StocksService } from './stocks.service';
+import { STOCKAPICONSTANTS } from './stocks.api.constants';
+
+const pluginName = STOCKAPICONSTANTS.STOCKSPLUGIN;
+export const stocksPlugin = {
+  name: pluginName,
+  version: STOCKAPICONSTANTS.VERSION,
+  register: async function(server) {
+    const getStockDetails = async (
+      symbol: String,
+      period: String,
+      token: String
+    ) => {
+      return StocksService.getStockDetails(symbol, period, token);
+    };
+
+    server.method(STOCKAPICONSTANTS.STOCK_DETAILS, getStockDetails, {
+      cache: {
+        cache: STOCKAPICONSTANTS.STOCK_DETAILS_CACHE,
+        expiresIn: STOCKAPICONSTANTS.EXPIRY_TIME,
+        generateTimeout: STOCKAPICONSTANTS.TIMEOUT
+      }
+    });
+
+    server.route({
+      method: STOCKAPICONSTANTS.GET,
+      path: STOCKAPICONSTANTS.PATH,
+      options: {
+        handler: async function(request) {
+          try {
+            const { symbol, period, token } = request.params;
+            return await server.methods.stockDetails(symbol, period, token);
+          } catch (error) {
+            return error;
+          }
+        }
+      }
+    });
+  }
+};

--- a/apps/stocks-api/src/plugin/stocks.service.ts
+++ b/apps/stocks-api/src/plugin/stocks.service.ts
@@ -1,0 +1,15 @@
+import { STOCKAPICONSTANTS } from './stocks.api.constants';
+
+export class StocksService {
+  static async getStockDetails(symbol: String, period: String, token: String) {
+    const Wreck = require('@hapi/wreck');
+    const wreck = Wreck.defaults({
+      timeout: STOCKAPICONSTANTS.TIMEOUT
+    });
+
+    const { response, payload } = await wreck.get(
+      `${STOCKAPICONSTANTS.APIURI}/${symbol}/chart/${period}?token=${token}`
+    );
+    return payload;
+  }
+}

--- a/apps/stocks/src/environments/environment.ts
+++ b/apps/stocks/src/environments/environment.ts
@@ -6,7 +6,7 @@ import { StocksAppConfig } from '@coding-challenge/stocks/data-access-app-config
 
 export const environment: StocksAppConfig = {
   production: false,
-  apiKey: '',
+  apiKey: 'Tpk_4a78b4b7fccc4441804ab5785df190eb',
   apiURL: 'https://sandbox.iexapis.com'
 };
 

--- a/libs/shared/ui/chart/src/lib/chart/chart.component.html
+++ b/libs/shared/ui/chart/src/lib/chart/chart.component.html
@@ -1,5 +1,5 @@
 <google-chart
-  *ngIf="data"
+  *ngIf="chartData"
   [title]="chart.title"
   [type]="chart.type"
   [data]="chartData"

--- a/libs/stocks/data-access-price-query/src/lib/+state/price-query.effects.ts
+++ b/libs/stocks/data-access-price-query/src/lib/+state/price-query.effects.ts
@@ -24,9 +24,7 @@ export class PriceQueryEffects {
       run: (action: FetchPriceQuery, state: PriceQueryPartialState) => {
         return this.httpClient
           .get(
-            `${this.env.apiURL}/beta/stock/${action.symbol}/chart/${
-              action.period
-            }?token=${this.env.apiKey}`
+            `/api/v1/stock/${action.symbol}/${action.period}/${this.env.apiKey}`
           )
           .pipe(
             map(resp => new PriceQueryFetched(resp as PriceQueryResponse[]))

--- a/package.json
+++ b/package.json
@@ -42,6 +42,8 @@
     "@angular/platform-browser-dynamic": "^7.0.0",
     "@angular/platform-server": "^7.0.0",
     "@angular/router": "^7.0.0",
+    "@hapi/catbox-memory": "5.0.0",
+    "@hapi/wreck": "17.0.0",
     "@nestjs/common": "5.5.0",
     "@nestjs/core": "5.5.0",
     "@ngrx/effects": "^7.4.0",


### PR DESCRIPTION
Changes done as part of this PR:
1) Added token for successful API call - environment.ts
2) HTML change to load the chart - chart.component.html
3) Change in url to invoke api using proxy config - price-query.effects.ts
4) Change to register the plugin and enabling cache - main.ts
5) New plugin with the server routes defined. Used server method for caching- stocks.plugin.ts
6) Invoked backend API call using Wreck - stocks.service.ts
8) Added constants file.

Note:
Used catbox-memory for  server side caching.
Used Wreck for HTTP request.
Proxying is enabled through proxy.config.json.

PFB the screenshot with caching for API call. Note that the initial call took 2.54s whereas the subsequent call took only 9ms.

![image](https://user-images.githubusercontent.com/60125332/72827012-fcfb0f80-3c9f-11ea-81e2-b5dbfb140db2.png)
